### PR TITLE
fix: avoid link conflicts in table of conflicts

### DIFF
--- a/solutions.cls
+++ b/solutions.cls
@@ -69,6 +69,7 @@
     headpunct={.},
     postheadhook={%
         \@exerciselabel{\arabic{chapter}}{\arabic{section}}{\arabic{exercise}}%
+        \phantomsection%
         \addcontentsline{toc}{subsection}{\arabic{chapter}.\arabic{section}.\arabic{exercise}}%
     },
     spacebelow=\parsep,


### PR DESCRIPTION
I'm not sure why this seems to work, but adding a `\phantomsection` before `\addcontentsline` fixed an issue on my local machine and in the GitHub build where exercise links in the TOC had collisions: for example, exercises 0.2.1 and 1.1.1 both pointed to exercise 0.2.1 (presumably because the exercise number is the same in both cases).

To see the issue, see [`solutions.pdf`](https://github.com/artemmavrin/categorical-logic-and-type-theory-solutions/actions/runs/14948523089/artifacts/3099728794) from 28610c1 and try clicking on Exercise 1.1.1 in the TOC.

This did _not_ happen on the Overleaf build, where the TOC links worked perfectly 🤷

I got this idea from a [Reddit thread](https://www.reddit.com/r/LaTeX/comments/1bdg6bw/comment/kuop555/).